### PR TITLE
Fix error for matplotlib package in Dockerfile

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -8,6 +8,9 @@ RUN apt-get update && apt-get install -y cmake libeigen3-dev libpcl-dev \
     ros-melodic-rviz ros-melodic-pcl-ros ros-melodic-eigen-conversions \
     libatlas-base-dev libgoogle-glog-dev libsuitesparse-dev libglew-dev wget
 
+# Install matplotlib
+RUN apt-get update && apt-get install -y python-pip python-tk && pip install matplotlib
+
 # Install ceres-solver
 WORKDIR /home/
 RUN wget https://github.com/ceres-solver/ceres-solver/archive/refs/tags/2.0.0.tar.gz


### PR DESCRIPTION
@zfc-zfc   
Thanks for your great work!  
I fix an error for Dockerfile that was contributed by me.  :smile:  

I didn't check matplotlibcpp when I gave you at first PR #20  
In this PR, I add some commands to install matplotlib package.   

I execute `LI_Init::plot_result()` function and it works fine.  
![Screenshot from 2022-09-14 14-16-19](https://user-images.githubusercontent.com/41863759/190375277-1aa7dbf7-43f9-402f-bc14-86581936d3b4.png)

I hope this PR is helpful.  

Thanks,  
 

