### PR TITLE
fix message generation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -62,14 +62,6 @@ find_package(Ceres REQUIRED)
 
 message(Eigen: ${EIGEN3_INCLUDE_DIR})
 
-include_directories(
-     ../../devel/include
-	${catkin_INCLUDE_DIRS} 
-  ${EIGEN3_INCLUDE_DIR}
-  ${PCL_INCLUDE_DIRS}
-  ${PYTHON_INCLUDE_DIRS}
-  include)
-
 add_message_files(
   FILES
   Pose6D.msg
@@ -86,6 +78,14 @@ catkin_package(
   DEPENDS EIGEN3 PCL
   INCLUDE_DIRS
 )
+
+include_directories(
+     ../../devel/include
+	${catkin_INCLUDE_DIRS} 
+  ${EIGEN3_INCLUDE_DIR}
+  ${PCL_INCLUDE_DIRS}
+  ${PYTHON_INCLUDE_DIRS}
+  include)
 
 add_executable(li_init
         src/laserMapping.cpp


### PR DESCRIPTION
current main branch doesn't build, this error occurs:

/home/nick/catkin_ws/src/LiDAR_IMU_Init/src/IMU_Processing.hpp:27:10: fatal error: lidar_imu_init/States.h: No such file or directory \#include <lidar_imu_init/States.h>

This is because of the order at which message generation is caled in the CMakeLists.txt Message generation must be called before we include these files which require the message types

Tested this on ubuntu20 and it builds fine now