### PR TITLE
Fix Robosense support

### DIFF
--- a/src/preprocess.cpp
+++ b/src/preprocess.cpp
@@ -260,7 +260,7 @@ Preprocess::process_cut_frame_pcl2(const sensor_msgs::PointCloud2::ConstPtr &msg
             added_pt.y = pl_orig.points[i].y;
             added_pt.z = pl_orig.points[i].z;
             added_pt.intensity = pl_orig.points[i].intensity;
-            added_pt.curvature = (pl_orig.points[i].timestamp - msg->header.stamp.toSec() + 0.1)* 1000.0;  //ms
+            added_pt.curvature = (pl_orig.points[i].timestamp - msg->header.stamp.toSec())* 1000.0;  //ms, if using the first point as the timestamp for whole scan (default, if using last: +0.1)
 
 
             double dist = added_pt.x * added_pt.x + added_pt.y * added_pt.y + added_pt.z * added_pt.z;

--- a/src/preprocess.h
+++ b/src/preprocess.h
@@ -97,7 +97,7 @@ POINT_CLOUD_REGISTER_POINT_STRUCT(pandar_ros::Point,
 namespace robosense_ros {
     struct EIGEN_ALIGN16 Point {
         PCL_ADD_POINT4D;
-        std::uint8_t intensity;
+        float intensity;
         std::uint16_t ring;
         double timestamp;
         EIGEN_MAKE_ALIGNED_OPERATOR_NEW
@@ -110,7 +110,7 @@ POINT_CLOUD_REGISTER_POINT_STRUCT(robosense_ros::Point,
                                           (float, y, y)
                                           (float, z, z)
                                           // use std::uint32_t to avoid conflicting with pcl::uint32_t
-                                          (std::uint8_t, intensity, intensity)
+                                          (float, intensity, intensity)
                                           (std::uint16_t, ring, ring)
                                           (double, timestamp, timestamp)
 )


### PR DESCRIPTION
Fix codes to match the latest Robosense driver default settings. 1. Robosense is using float as intensity by default in drivers. 2. Robosense is using the first point's time as the timestamp for a whole scan by default. One should +0.1 in calculating added_pt.curvature only when setting to use the last point's time.